### PR TITLE
[comskip] 0.0.10

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 
+**<span style="color:#56adda">0.0.10</span>**
+- changed init.d to install the plugin by building from github - installs the latest version with ffmpeg compatibility fixes
+- expands use_hw option to be used for either nvidia or intel QSV GPUs
+- auto detects GPU
+- falls back to CPU based decode if use_hw is selected and plugin determines no GPU or no useable GPU was found
+
 **<span style="color:#56adda">0.0.9</span>**
 - add mimetype override and comskip command line arg to support ts files
 - add parse_progress to display estimated time of completion

--- a/comchap/comchap
+++ b/comchap/comchap
@@ -31,7 +31,8 @@ deletetxt=true
 verbose=false
 lockfile=""
 workdir=""
-usehw=false
+usecuvid=false
+useqsv=false
 
 while [[ $# -gt 0 ]]
 do
@@ -49,8 +50,12 @@ case $key in
     verbose=true
     shift
     ;;
-    --use-hw)
-    usehw=true
+    --cuvid)
+    usecuvid=true
+    shift
+    ;;
+    --qsv)
+    useqsv=true
     shift
     ;;
     --ffmpeg=*)
@@ -78,15 +83,15 @@ case $key in
     exit 1
     ;;
     *)
-    if [ -z $infile ]; then
-      infile=$1
+    if [ -z "$infile" ]; then
+      infile="$1"
       if [ ! -f "$infile" ]; then
         echo "Inputfile '$infile' doesn't exist. Please check."
         exit 1
       fi
     else
-      if [ -z $outfile ]; then
-        outfile=$1
+      if [ -z "$outfile" ]; then
+        outfile="$1"
       else
         echo "Error: too many parameters. Inputfile and Outputfile already defined. Please check your command."
         exit 1
@@ -156,17 +161,23 @@ fi
 
 infile_ext="${infile##*.}"
 if [ ! -f "$edlfile" ]; then
-  if [ "$usehw" == false ]; then
+  if [ "$useqsv" == false ] && [ "$usecuvid" == false ]; then
     if [ "$infile_ext" != 'ts' ]; then
       $comskipPath --ini="$comskipini" "$infile"
     else
       $comskipPath -t --ini="$comskipini" "$infile"
     fi
-  else
+  elif [ "$usecuvid" == true ]; then
     if [ "$infile_ext" != 'ts' ]; then
       $comskipPath --cuvid --ini="$comskipini" "$infile"
     else
       $comskipPath -t --cuvid --ini="$comskipini" "$infile"
+    fi
+  else
+    if [ "$infile_ext" != 'ts' ]; then
+      $comskipPath --qsv --ini="$comskipini" "$infile"
+    else
+      $comskipPath -t --qsv --ini="$comskipini" "$infile"
     fi
   fi
 

--- a/comchap/comcut
+++ b/comchap/comcut
@@ -30,7 +30,8 @@ deletelogo=true
 deletetxt=true
 lockfile=""
 workdir=""
-usehw=false
+usecuvid=false
+useqsv=false
 
 while [[ $# -gt 0 ]]
 do
@@ -44,8 +45,12 @@ case $key in
     deletemeta=false
     shift
     ;;
-    --use-hw)
-    usehw=true
+    --cuvid)
+    usecuvid=true
+    shift
+    ;;
+    --qsv)
+    useqsv=true
     shift
     ;;
     --ffmpeg=*)
@@ -74,14 +79,14 @@ case $key in
     ;;
     *)
     if [ -z "$infile" ]; then
-      infile=$1
+      infile="$1"
       if [ ! -f "$infile" ]; then
         echo "Inputfile '$infile' doesn't exist. Please check."
         exit 1
       fi
     else
       if [ -z "$outfile" ]; then
-        outfile=$1
+        outfile="$1"
       else
         echo "Error: too many parameters. Inputfile and Outputfile already defined. Please check your command."
         exit 1
@@ -144,17 +149,23 @@ fi
 
 infile_ext="${infile##*.}"
 if [ ! -f "$edlfile" ]; then
-  if [ "$usehw" == false ]; then
+  if [ "$useqsv" == false ] && [ "$usecuvid" == false ]; then
     if [ "$infile_ext" != 'ts' ]; then
-      $comskipPath $comskipoutput --ini="$comskipini" "$infile"
+      $comskipPath --ini="$comskipini" "$infile"
     else
-      $comskipPath -t $comskipoutput --ini="$comskipini" "$infile"
+      $comskipPath -t --ini="$comskipini" "$infile"
+    fi
+  elif [ "$usecuvid" == true ]; then
+    if [ "$infile_ext" != 'ts' ]; then
+      $comskipPath --cuvid --ini="$comskipini" "$infile"
+    else
+      $comskipPath -t --cuvid --ini="$comskipini" "$infile"
     fi
   else
     if [ "$infile_ext" != 'ts' ]; then
-      $comskipPath $comskipoutput --cuvid --ini="$comskipini" "$infile"
+      $comskipPath --qsv --ini="$comskipini" "$infile"
     else
-      $comskipPath $comskipoutput -t --cuvid --ini="$comskipini" "$infile"
+      $comskipPath -t --qsv --ini="$comskipini" "$infile"
     fi
   fi
 fi

--- a/description.md
+++ b/description.md
@@ -74,5 +74,6 @@ Chapters are still added to the resulting file.
 </div>
 
 #### <span style="color:blue">Use hardware acceleration for commercial detection</span>
-Uses hardware acceleration for commercial detection - compatible only with Nvidia cuvid currently.
-Do not select if you do not have a compatible Nvidia GPU.
+Uses hardware acceleration for commercial detection - compatible with nvidia and QSV GPUs.
+Autodetects specific GPU installed and will fallback to no hardware acceleration if no useable GPU was found.
+Prefers nvidia if both nvidia and qsv GPUs are found.

--- a/info.json
+++ b/info.json
@@ -14,5 +14,5 @@
         "on_postprocessor_task_results":1
     },
     "tags": "video,pvr,library file test",
-    "version": "0.0.9"
+    "version": "0.0.10"
 }

--- a/init.d/install-comskip.sh
+++ b/init.d/install-comskip.sh
@@ -5,16 +5,25 @@
 # File Created: 28 September 2021, 8:03 AM
 # Author: josh5
 # -----
-# Last Modified: 28 September 2021, 8:03 AM
+# Last Modified: 04 December 2025, 6:15 PM
 # Modified By: josh5
 # -
 
 # Script is executed by the Unmanic container on startup to auto-install dependencies
 
-if ! command -v comskip &> /dev/null; then
+if ! command -v comskip &> /dev/null || [[ $(( $(comskip 2>&1 | head -1 | awk '{ print $2 }' | tr -d ',' | awk -F'.' '{print $2}') )) < 83 ]]; then
     echo "**** Installing Comskip ****"
-    apt-get update
-    apt-get install -y comskip
+    /usr/bin/apt-get update
+    /usr/bin/apt-get install -y autoconf libtool pkg-config make libswscale-dev libavformat-dev libavcodec-dev libavutil-dev libargtable2-dev
+    cd /root
+    wget https://github.com/erikkaashoek/Comskip/archive/refs/heads/master.zip
+    wait $!
+    unzip master.zip
+    cd Comskip-master
+    ./autogen.sh
+    ./configure --disable-dependency-tracking
+    make
+    cp -a /root/Comskip-master/comskip /usr/local/bin/comskip
 else
-    echo "**** Comskip already installed ****"
+  echo "**** Comskip already installed ****"
 fi

--- a/plugin.py
+++ b/plugin.py
@@ -27,6 +27,9 @@ import mimetypes
 import os
 import stat
 import re
+import subprocess
+from pathlib import Path
+
 from configparser import NoSectionError, NoOptionError
 
 from unmanic.libs.unplugins.settings import PluginSettings
@@ -202,6 +205,43 @@ def comskip_config_file(settings):
 
     return comskip_config_file
 
+def get_render_vendor():
+    render_root= Path('/dev/dri')
+    render_dev = [render_device for render_device in render_root.glob("render*")]
+    #if render_dev is not empty, render devices were found
+
+    render_names = [dev.name for dev in render_dev]
+    for rdev in render_names:
+        if os.path.exists(os.path.join("/sys/class/drm", render_names[0], "device/vendor")):
+            vendor = Path(os.path.join("/sys/class/drm", render_names[0], "device/vendor"))
+            vendor_text = vendor.read_text()
+            if "0x8086" in vendor_text:
+                return rdev
+    return ""
+
+def get_gpu():
+    command = '[[ $(compgen -G /dev/nvidia*) != "" ]] && [[ $(command -v nvidia-smi) != "" ]] && echo "nvidia_gpu_and_driver_installed"'
+    result = subprocess.run (["bash", "-c", command], capture_output=True, text=True, check=False)
+    if "nvidia_gpu_and_driver_installed" in result.stdout:
+        logger.info(f"nvidia GPU detected in container and driver installed")
+        decoder = "--cuvid"
+    else:
+        logger.info(f"nvidia GPU not detected in container or driver not installed")
+        decoder = ""
+
+    if get_render_vendor() == '':
+        logger.info(f"QSV capable GPU  not detected in container")
+    else:
+        command = '[[ $(vainfo --display drm --device "$INTEL_NODE" 2>/dev/null) ]] && echo "intel driver installed"'
+        result = subprocess.run (["bash", "-c", command], capture_output=True, text=True, check=False)
+        if "intel driver installed" in result.stdout:
+            logger.info(f"QSV GPU driver detected as installed  in container")
+            if decoder == "--cuvid":
+                decoder += "+ --qsv"
+            else:
+                decoder = "--qsv"
+    # if cuvid nor qsv is detected, decoder should be "" here
+    return decoder
 
 def build_comskip_args(abspath, settings):
     config_file = comskip_config_file(settings)
@@ -210,15 +250,24 @@ def build_comskip_args(abspath, settings):
     file_ext = os.path.splitext(abspath)[1]
     use_hw = settings.get_setting('use_hw')
     comskip_args = ['comskip','--ini={}'.format(config_file),'--output={}'.format(file_dirname),'--output-filename={}'.format(file_sans_ext),abspath]
+    if use_hw:
+        decoder = get_gpu()
+        if decoder == "--cuvid + --qsv":
+            logger.info(f"Can use either cuvid or qsv - picking cuvid")
+            decoder == '--cuvid'
+        elif decoder == "":
+            use_hw = False
+            logger.info(f"h/w decoding was configured but no nvidia or qsv decoder was found - falling back to cpu based decoding")
+
     if (not use_hw) & (file_ext == '.ts'):
         comskip_args.insert(1, '-t')
 
     if use_hw & (file_ext != '.ts'):
-        comskip_args.insert(1, '--cuvid')
+        comskip_args.insert(1, decoder)
 
     if use_hw & (file_ext == '.ts'):
         comskip_args.insert(1, '-t')
-        comskip_args.insert(2, '--cuvid')
+        comskip_args.insert(2, decoder)
 
     return comskip_args
 
@@ -230,6 +279,15 @@ def build_comchap_args(abspath, file_out, settings):
     st = os.stat(comchap_path)
     os.chmod(comchap_path, st.st_mode | stat.S_IEXEC)
     use_hw = settings.get_setting('use_hw')
+    if use_hw:
+        decoder = get_gpu()
+        if decoder == "--cuvid + --qsv":
+            logger.info(f"For comchap - can use either cuvid or qsv - picking cuvid")
+            decoder == '--cuvid'
+        elif decoder == "":
+            use_hw = False
+            logger.info(f"for comchap - h/w decoding was configured but no nvidia or qsv decoder was found - falling back to cpu based decoding")
+
     if not use_hw:
         args = [
             comchap_path,
@@ -244,7 +302,7 @@ def build_comchap_args(abspath, file_out, settings):
         args = [
             comchap_path,
             '--comskip-ini={}'.format(config_file),
-            '--use-hw',
+            decoder,
             '--keep-edl',
             '--keep-meta',
             '--verbose',
@@ -261,6 +319,15 @@ def build_comcut_args(abspath, file_out, settings):
     st = os.stat(comcut_path)
     os.chmod(comcut_path, st.st_mode | stat.S_IEXEC)
     use_hw = settings.get_setting('use_hw')
+    if use_hw:
+        decoder = get_gpu()
+        if decoder == "--cuvid + --qsv":
+            logger.info(f"For comcut - can use either cuvid or qsv - picking cuvid")
+            decoder == '--cuvid'
+        elif decoder == "":
+            use_hw = False
+            logger.info(f"for comcut - h/w decoding was configured but no nvidia or qsv decoder was found - falling back to cpu based decoding")
+
     if not use_hw:
         args = [
             comcut_path,
@@ -274,7 +341,7 @@ def build_comcut_args(abspath, file_out, settings):
         args = [
             comcut_path,
             '--comskip-ini={}'.format(config_file),
-            '--use-hw',
+            decoder,
             '--keep-edl',
             '--keep-meta',
             abspath,


### PR DESCRIPTION
- changed init.d to install the plugin by building from github source (the version unmanic currently installs from the ubuntu repo is circa 2019) - installs the latest comskip version that has recent ffmpeg compatibility fixes
- expands use_hw option to be used for either nvidia or intel QSV GPUs
- auto detects GPU
- falls back to CPU based decode if use_hw is selected and plugin cannot detect GPU or if no useable GPU was found