### PR TITLE
[comskip] 0.0.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.11</span>**
+- fix install script - remove the wait line in the script
+
 **<span style="color:#56adda">0.0.10</span>**
 - changed init.d to install the plugin by building from github - installs the latest version with ffmpeg compatibility fixes
 - expands use_hw option to be used for either nvidia or intel QSV GPUs

--- a/info.json
+++ b/info.json
@@ -14,5 +14,5 @@
         "on_postprocessor_task_results":1
     },
     "tags": "video,pvr,library file test",
-    "version": "0.0.10"
+    "version": "0.0.11"
 }

--- a/init.d/install-comskip.sh
+++ b/init.d/install-comskip.sh
@@ -17,7 +17,6 @@ if ! command -v comskip &> /dev/null || [[ $(( $(comskip 2>&1 | head -1 | awk '{
     /usr/bin/apt-get install -y autoconf libtool pkg-config make libswscale-dev libavformat-dev libavcodec-dev libavutil-dev libargtable2-dev
     cd /root
     wget https://github.com/erikkaashoek/Comskip/archive/refs/heads/master.zip
-    wait $!
     unzip master.zip
     cd Comskip-master
     ./autogen.sh


### PR DESCRIPTION
fixed the init.d install script - it previously contained a `wait $!` which was unncessary and in ubuntu 24.04 causes an error when the referenced variable is unbound.  Removing the line allows the script to proceed.  it will also work on earlier versions of ubuntu as the line essentially wasn't doing anything any longer.  it was something i should have removed awhile ago..