### PR TITLE
[comskip] 0.0.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.11</span>**
+- make init.d installer compatible with new ubuntu 24 unmanic container
+
 **<span style="color:#56adda">0.0.10</span>**
 - changed init.d to install the plugin by building from github - installs the latest version with ffmpeg compatibility fixes
 - expands use_hw option to be used for either nvidia or intel QSV GPUs

--- a/info.json
+++ b/info.json
@@ -14,5 +14,5 @@
         "on_postprocessor_task_results":1
     },
     "tags": "video,pvr,library file test",
-    "version": "0.0.10"
+    "version": "0.0.11"
 }

--- a/init.d/install-comskip.sh
+++ b/init.d/install-comskip.sh
@@ -15,15 +15,12 @@ if ! command -v comskip &> /dev/null || [[ $(( $(comskip 2>&1 | head -1 | awk '{
     echo "**** Installing Comskip ****"
     /usr/bin/apt-get update
     /usr/bin/apt-get install -y autoconf libtool pkg-config make libswscale-dev libavformat-dev libavcodec-dev libavutil-dev libargtable2-dev
-    cd /root
-    wget https://github.com/erikkaashoek/Comskip/archive/refs/heads/master.zip
-    wait $!
-    unzip master.zip
-    cd Comskip-master
-    ./autogen.sh
-    ./configure --disable-dependency-tracking
-    make
-    cp -a /root/Comskip-master/comskip /usr/local/bin/comskip
+    mkdir -p /tmp/comskip
+    wget -P /tmp/comskip https://github.com/erikkaashoek/Comskip/archive/refs/heads/master.zip
+    unzip -d /tmp/comskip /tmp/comskip/master.zip
+    (cd /tmp/comskip/Comskip-master && ./autogen.sh && ./configure --disable-dependency-tracking && make)
+    cp -a /tmp/comskip/Comskip-master/comskip /usr/local/bin/comskip
+    rm -rf /tmp/comskip
 else
   echo "**** Comskip already installed ****"
 fi


### PR DESCRIPTION
made init.d install-comskip script compatible with unmanic's new ubuntu 24 based container.
-builds comskip from source in a working directory at /tmp/comskip
-moves comskip executable to /usr/local/bin after build
-removes install files upon completion